### PR TITLE
Use nested `current_page` context.

### DIFF
--- a/apps/deploy/templates/chief/base.html
+++ b/apps/deploy/templates/chief/base.html
@@ -10,7 +10,7 @@
     <meta name="author" content="">
     <link rel="icon" href="../../favicon.ico">
 
-    <title>{{ title }}</title>
+    <title>{{ current_page.title }}</title>
 
     <link href="{% static 'bootstrap/dist/css/bootstrap.min.css' %}" rel="stylesheet">
 


### PR DESCRIPTION
I haven't actually tested this out (I'm not set up to run this locally yet), but I believe this is why there's not currently a title attribute.
@benrudolph 
